### PR TITLE
fix: sessions with similar name as current are no longer excluded

### DIFF
--- a/bin/tea.sh
+++ b/bin/tea.sh
@@ -32,7 +32,7 @@ run_type="serverless"
 
 get_sessions_by_last_used() {
     tmux list-sessions -F '#{session_last_attached} #{session_name}' |
-        sort --numeric-sort --reverse | awk '{print $2}' | grep -v "$(tmux display-message -p '#S')"
+        sort --numeric-sort --reverse | awk '{print $2}' | grep -v -E "^$(tmux display-message -p '#S')$"
 }
 
 get_zoxide_results() {


### PR DESCRIPTION
Consider the following 3 sessions: foo, foo-bar, baz. Prior to this fix, while foo is the current session, foo-bar would not show up in the session list. Similarly, while foo-bar the current session, foo would not show up in the list. To switch to those missing sessions, the user would have to scroll up to the zoxide path for the session or fuzzy search it. This is makes it difficult to quickly jump back and forth between two or more similarly named sessions.

The cause of this bug is in the logic that controls finding and excluding the current session from the list of sessions. It uses grep, but the match is too permissive, resulting in partial matches as well.

This fix updates the grep command to look for an exact match in the session name, ensuring other sessions with the current session name as a substring of the name will still correctly display.

## Why

- [x] I want to fix the issue #7 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
