### PR TITLE
Add options to change preview and input positions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ You can set the **preview position** to "top" (default) or "bottom":
 set -g @tea-preview-position "bottom"
 ```
 
+#### input position
+
+You can set the **input position** to "default", "reverse", or "reverse-list":
+
+```tmux
+set -g @tea-layout "reverse"
+```
+
 ## Behind The Code
 
 ### 🌈 Inspiration

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ You can set the session name to be the full path you select instead of the direc
 set -g @tea-session-name "full-path"
 ```
 
+#### preview position
+
+You can set the **preview position** to "top" (default) or "bottom":
+
+```tmux
+set -g @tea-preview-position "bottom"
+```
+
 ## Behind The Code
 
 ### 🌈 Inspiration

--- a/bin/tea.sh
+++ b/bin/tea.sh
@@ -11,6 +11,15 @@ if [[ "$preview_position_option" = "bottom" ]]; then
     preview_position="bottom"
 fi
 
+layout_option=$(tmux show-option -gqv "@tea-layout")
+layout="default"
+if [[ "$layout_option" = "reverse" ]]; then
+    layout="reverse"
+fi
+if [[ "$layout_option" = "reverse-list" ]]; then
+    layout="reverse-list"
+fi
+
 session_preview_cmd="tmux capture-pane -ep -t"
 dir_preview_cmd="eza -ahlT -L=2 -s=extension --group-directories-first --icons --git --git-ignore --no-user --color=always --color-scale=all --color-scale-mode=gradient"
 preview="$session_preview_cmd {} 2&>/dev/null || eval $dir_preview_cmd {}"
@@ -75,7 +84,7 @@ else
             --bind "$find_bind" --bind "$session_bind" --bind "$tab_bind" --bind "$window_bind" --bind "$t_bind" \
             --bind "$zoxide_bind" --bind "$kill_bind" --border-label "$border_label" --header "$header" \
             --no-sort --prompt "$prompt" --marker "$marker" --preview "$preview" \
-            --preview-window="$preview_position",75% $fzf_tmux_options)
+            --preview-window="$preview_position",75% $fzf_tmux_options --layout="$layout")
         ;;
     detached)
         result=$(get_fzf_results | fzf \

--- a/bin/tea.sh
+++ b/bin/tea.sh
@@ -5,6 +5,12 @@ home_replacer=""
 fzf_tmux_options=${FZF_TMUX_OPTS:-"-p 90%"}
 [[ "$HOME" =~ ^[a-zA-Z0-9\-_/.@]+$ ]] && home_replacer="s|^$HOME/|~/|"
 
+preview_position_option=$(tmux show-option -gqv "@tea-preview-position")
+preview_position="top"
+if [[ "$preview_position_option" = "bottom" ]]; then
+    preview_position="bottom"
+fi
+
 session_preview_cmd="tmux capture-pane -ep -t"
 dir_preview_cmd="eza -ahlT -L=2 -s=extension --group-directories-first --icons --git --git-ignore --no-user --color=always --color-scale=all --color-scale-mode=gradient"
 preview="$session_preview_cmd {} 2&>/dev/null || eval $dir_preview_cmd {}"
@@ -16,10 +22,10 @@ header="^f   ^j   ^s   ^w   ^x "
 
 t_bind="ctrl-t:abort"
 tab_bind="tab:down,btab:up"
-session_bind="ctrl-s:change-prompt(  )+reload(tmux list-sessions -F '#S')+change-preview-window(top,85%)"
+session_bind="ctrl-s:change-prompt(  )+reload(tmux list-sessions -F '#S')+change-preview-window($preview_position,85%)"
 zoxide_bind="ctrl-j:change-prompt(  )+reload(zoxide query -l | sed -e \"$home_replacer\")+change-preview(eval $dir_preview_cmd {})+change-preview-window(right)"
 find_bind="ctrl-f:change-prompt(  )+reload(fd -H -d 2 -t d . ~)+change-preview($dir_preview_cmd {})+change-preview-window(right)"
-window_bind="ctrl-w:change-prompt(  )+reload(tmux list-windows -a -F '#{session_name}:#{window_index}')+change-preview($session_preview_cmd {})+change-preview-window(top)"
+window_bind="ctrl-w:change-prompt(  )+reload(tmux list-windows -a -F '#{session_name}:#{window_index}')+change-preview($session_preview_cmd {})+change-preview-window($preview_position)"
 kill_bind="ctrl-x:change-prompt(  )+execute-silent(tmux kill-session -t {})+reload-sync(tmux list-sessions -F '#S' && zoxide query -l | sed -e \"$home_replacer\")"
 
 # determine if the tmux server is running
@@ -69,7 +75,7 @@ else
             --bind "$find_bind" --bind "$session_bind" --bind "$tab_bind" --bind "$window_bind" --bind "$t_bind" \
             --bind "$zoxide_bind" --bind "$kill_bind" --border-label "$border_label" --header "$header" \
             --no-sort --prompt "$prompt" --marker "$marker" --preview "$preview" \
-            --preview-window=top,75% $fzf_tmux_options)
+            --preview-window="$preview_position",75% $fzf_tmux_options)
         ;;
     detached)
         result=$(get_fzf_results | fzf \


### PR DESCRIPTION
These options allow for optional neck protection by moving input to the top:
- Add option @tea-preview-position with "bottom" option.
- Add option @tea-layout with options to set input position.

![image](https://github.com/user-attachments/assets/1924acb9-50d6-4b8c-a160-a5e1f2763767)

