### PR TITLE
feat: `C-t` can be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ln -sfnv $PWD/bin/tea.sh  ~/.local/bin/tea # Add tea to $PATH, make sure ~/.loca
 There are two ways to open tea
 
 - `<prefix> - t`, this can be configured with the `@tea-bind` option e.g: `set -g @tea-bind "t"`
-- <kbd>Ctrl</kbd>+<kbd>t</kbd> alternate binding for a smoother experience. (this can be configured with the `@tea-bind-alt` option and if set to `"false"` this keybind is ignored)
+- <kbd>Ctrl</kbd>+<kbd>t</kbd> alternate binding, this can be configured with the `@tea-alt-bind` option, set it to `"false"` to disable
 
 #### Keybindings
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ln -sfnv $PWD/bin/tea.sh  ~/.local/bin/tea # Add tea to $PATH, make sure ~/.loca
 There are two ways to open tea
 
 - `<prefix> - t`, this can be configured with the `@tea-bind` option e.g: `set -g @tea-bind "t"`
-- <kbd>Ctrl</kbd>+<kbd>t</kbd> alternate binding for a smoother experience.
+- <kbd>Ctrl</kbd>+<kbd>t</kbd> alternate binding for a smoother experience. (this can be configured with the `@tea-bind-alt` option and if set to `"false"` this keybind is ignored)
 
 #### Keybindings
 

--- a/tea.tmux
+++ b/tea.tmux
@@ -13,7 +13,7 @@ tmux_option_or_fallback() {
 
 tmux bind-key "$(tmux_option_or_fallback "@tea-bind" "t")" run-shell "$CURRENT_DIR/bin/tea.sh"
 
-ALT_KEY_BIND="$(tmux show-option -gqv "@tea-bind-alt")"
+ALT_KEY_BIND="$(tmux_option_or_fallback "@tea-alt-bind" "C-t")"
 if [ "$ALT_KEY_BIND" != "false" ]; then
-    tmux bind-key -n "$(tmux_option_or_fallback "@tea-bind-alt" "C-t")" run-shell "$CURRENT_DIR/bin/tea.sh"
+    tmux bind-key -n "$ALT_KEY_BIND" run-shell "$CURRENT_DIR/bin/tea.sh"
 fi

--- a/tea.tmux
+++ b/tea.tmux
@@ -13,6 +13,7 @@ tmux_option_or_fallback() {
 
 tmux bind-key "$(tmux_option_or_fallback "@tea-bind" "t")" run-shell "$CURRENT_DIR/bin/tea.sh"
 
-# Open tea on control + t
-tmux bind-key -n C-t run-shell "$CURRENT_DIR/bin/tea.sh"
-
+ALT_KEY_BIND="$(tmux show-option -gqv "@tea-bind-alt")"
+if [ "$ALT_KEY_BIND" != "false" ]; then
+    tmux bind-key -n "$(tmux_option_or_fallback "@tea-bind-alt" "C-t")" run-shell "$CURRENT_DIR/bin/tea.sh"
+fi


### PR DESCRIPTION
## What

What does this pull request accomplish?

- Make `C-t` bind disableable (weird word)

## How

What code changes were made to accomplish it?

- Check for the value `false` as the `@tea-bind-alt` option

## Why

- [X] I want to fix the issue #12 
- [X] I want to add a new feature
- [ ] I want to improve the documentation

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
